### PR TITLE
Fix `dims` in Java grammar

### DIFF
--- a/syncode/parsers/grammars/java.lark
+++ b/syncode/parsers/grammars/java.lark
@@ -192,7 +192,7 @@ dim_exprs: dim_expr+
 
 dim_expr: "[" expression "]"
 
-dims: "[" "]"+
+dims: ("[" "]")+
 
 field_access: primary "." CNAME | "super" "." CNAME
 


### PR DESCRIPTION
This term should mean `[][][][]` instead of `[]]]]`