### PR TITLE
Fix NL rule to handle multiline comments correctly

### DIFF
--- a/syncode/parsers/grammars/go.lark
+++ b/syncode/parsers/grammars/go.lark
@@ -301,7 +301,7 @@ nls: NL+
 NAME : /[a-zA-Z_]\w*/
 
 COMMENT : /\/\/[^\n]*\n/
-NL: COMMENT | /(\r?\n[\t ]*)+/ | /\/\*[^\n]*\n(\*+[^*\/]|[^*])*\*+\//s
+NL: COMMENT | /(\r?\n[\t ]*)+/ | /\/\*(\*+[^*\/\n]|[^*\n])*\**\n(\*+[^*\/]|[^*])*\*+\//s
 
 // %import common.WS_INLINE
 // %ignore WS_INLINE


### PR DESCRIPTION
Wrong behavior: after seeing `/*`, always look for `\n`.
Correct behavior: after seeing `/*`, look for `\n` only when there is no `*/` before that.